### PR TITLE
Add 'backorders' to product and variation

### DIFF
--- a/lib/woocommerce_api/resources/product.rb
+++ b/lib/woocommerce_api/resources/product.rb
@@ -92,6 +92,7 @@ module WoocommerceAPI
     attribute :default_attributes, Hash
     attribute :sale_price_dates_from, DateTime
     attribute :sale_price_dates_to, DateTime
+    attribute :backorders
     attribute :product_url
     attribute :button_text
     attribute :enable_html_description, Boolean, default: true

--- a/lib/woocommerce_api/resources/variation.rb
+++ b/lib/woocommerce_api/resources/variation.rb
@@ -57,6 +57,7 @@ module WoocommerceAPI
     attribute :visible, Boolean
 
     # Write Only
+    attribute :backorders
     attribute :sale_price_dates_from, DateTime
     attribute :sale_price_dates_to, DateTime
   end


### PR DESCRIPTION
Write only attributes `backorders`
- false (not allow backordering)
- true (allow backordering) _but not working through WC-API_
- 'notify' (allow and notify customer) 