### PR TITLE
Add User-Agent to headers

### DIFF
--- a/lib/woocommerce_api/client.rb
+++ b/lib/woocommerce_api/client.rb
@@ -5,7 +5,9 @@ module WoocommerceAPI
       Thread.current["WoocommerceAPI"] ||= {
         parser: HTTParty::Parser,
         format: :json,
-        headers: { "Accept" => "application/json", "Content-Type" => "application/json" }
+        headers: { "Accept"       => "application/json",
+                   "Content-Type" => "application/json",
+                   "User-Agent"   => "Ruby" }
       }
     end
 


### PR DESCRIPTION
# Problem
- some servers expect to read `User-Agent` and makes authentication fail

# Implement
- Add `User-Agent` to headers