### PR TITLE
Add a load method so we don't have to call initialize on an existing object

### DIFF
--- a/lib/woocommerce_api/concerns/singleton.rb
+++ b/lib/woocommerce_api/concerns/singleton.rb
@@ -98,7 +98,7 @@ module WoocommerceAPI
 
       def reload
         return unless persisted?
-        self.send(:initialize, self.class.find(self.id).attributes)
+        self.load(self.class.find(self.id).attributes)
       end
 
       def to_path

--- a/lib/woocommerce_api/resource.rb
+++ b/lib/woocommerce_api/resource.rb
@@ -44,12 +44,15 @@ module WoocommerceAPI
 
     def initialize(params={})
       @raw_params = params.dup
+      load(params)
+      super()
+    end
 
+    def load(params)
       params.each do |attr, value|
         self.send("#{attr}=", value) if self.respond_to?("#{attr}=", true)
       end if params
-
-      super()
+      self
     end
 
     def self.http_request(verb, url, options={})

--- a/lib/woocommerce_api/resources/product.rb
+++ b/lib/woocommerce_api/resources/product.rb
@@ -3,7 +3,7 @@ require "woocommerce_api/resources/variation"
 module WoocommerceAPI
   class Product < Resource
 
-    def initialize(attributes={})
+    def load(attributes)
       # Rename restricted attributes
       if attributes['attributes']
         attributes['wc_attributes'] = attributes.delete('attributes')

--- a/lib/woocommerce_api/resources/variation.rb
+++ b/lib/woocommerce_api/resources/variation.rb
@@ -3,7 +3,7 @@ require "woocommerce_api/resources/dimensions"
 
 module WoocommerceAPI
   class Variation < Resource
-    def initialize(attributes={})
+    def load(attributes)
       # Rename restricted attributes
       if attributes['attributes']
         attributes['wc_attributes'] = attributes.delete('attributes')


### PR DESCRIPTION
Calling initialize on an existing object scares me a little. (I assume it's safe, but want to be careful)
Borrowing from activeresource I've added a `load` method which handles all the heavy lifting of loading the attributes into the object.