### PR TITLE
Exclude images

### DIFF
--- a/lib/woocommerce_api/concerns/singleton.rb
+++ b/lib/woocommerce_api/concerns/singleton.rb
@@ -110,11 +110,11 @@ module WoocommerceAPI
         attr_json = super(options)
         if options && options[:root]
           attr_json[singleton_name].each do |key, value|
-            attr_json[singleton_name][key] = value.as_json(root: false)
+            attr_json[singleton_name][key] = value.as_json(options.merge(root: false))
           end
         else
           attr_json.each do |key, value|
-            attr_json[key] = value.as_json(root: false)
+            attr_json[key] = value.as_json(options.merge(root: false))
           end
         end
         attr_json

--- a/lib/woocommerce_api/concerns/singleton.rb
+++ b/lib/woocommerce_api/concerns/singleton.rb
@@ -106,7 +106,7 @@ module WoocommerceAPI
       end
 
       # Every nested assocation. by default #as_json(root: false) could be applied
-      def as_json(options=nil)
+      def as_json(options={})
         attr_json = super(options)
         if options && options[:root]
           attr_json[singleton_name].each do |key, value|

--- a/lib/woocommerce_api/resources/product.rb
+++ b/lib/woocommerce_api/resources/product.rb
@@ -11,7 +11,7 @@ module WoocommerceAPI
       super
     end
 
-    def as_json(options=nil)
+    def as_json(options={})
       wc_attributes = super(options)
       if attributes[:wc_attributes] && !attributes[:wc_attributes].empty?
         if options && !options[:root]
@@ -26,6 +26,7 @@ module WoocommerceAPI
       wc_attributes['product'].delete('categories')
       wc_attributes['product'].delete('tags')
       wc_attributes['product'].delete('default_attributes')
+      wc_attributes['product'].delete('images') unless options[:include] && options[:include].include?(:images)
 
       wc_attributes
     end
@@ -92,7 +93,7 @@ module WoocommerceAPI
     attribute :visible           , Boolean , writer: :private
 
     # Write Only
-    attribute :default_attributes           , Hash    
+    attribute :default_attributes           , Hash
     attribute :sale_price_dates_from        , DateTime
     attribute :sale_price_dates_to          , DateTime
     attribute :backorders                   , Boolean

--- a/lib/woocommerce_api/resources/variation.rb
+++ b/lib/woocommerce_api/resources/variation.rb
@@ -16,10 +16,13 @@ module WoocommerceAPI
       if attributes[:wc_attributes] && !attributes[:wc_attributes].empty?
         if options && !options[:root]
           wc_attributes['attributes'] = attributes[:wc_attributes]
+          wc_attributes.delete('image') unless options && options[:include] && options[:include].include?(:images)
         else
           wc_attributes['variation']['attributes'] = attributes[:wc_attributes]
+          wc_attributes['variation'].delete('images') unless options[:include] && options[:include].include?(:images)
         end
       end
+
       wc_attributes
     end
 
@@ -58,7 +61,7 @@ module WoocommerceAPI
     attribute :visible              , Boolean , writer: :private
 
     # Write Only
-    attribute :backorders           , Boolean 
+    attribute :backorders           , Boolean
     attribute :sale_price_dates_from, DateTime
     attribute :sale_price_dates_to  , DateTime
   end


### PR DESCRIPTION
Exclude `images` from json payload by default 
- preventing mistakenly touch product's images / variation's image

For upload or edit images need to use `.save(with: [:images])`