### PR TITLE
Remove Byte Order Mark (BOM) before parsing response body

### DIFF
--- a/lib/woocommerce_api/resource.rb
+++ b/lib/woocommerce_api/resource.rb
@@ -68,10 +68,7 @@ module WoocommerceAPI
       if response.success?
         # Restric format to be JSON
         begin
-          # Some websites are including Byte Order Mark (BOM) on the response body
-          # which causes the response body to parsed correctly
-          response.body.sub!(/^\xEF\xBB\xBF/, '')
-          JSON.parse(response.body)
+          parse_response(response)
         rescue JSON::ParserError => ex
           raise(ClientError.new('woocommerce_parse_json_error', response))
         rescue Net::ReadTimeout => ex
@@ -80,6 +77,10 @@ module WoocommerceAPI
       else
         raise(ClientError.new(response.code, response))
       end
+    end
+
+    def self.parse_response(response)
+      JSON.parse(response.body.match(/({.*})/).to_s)
     end
   end # Resource
 end

--- a/lib/woocommerce_api/resource.rb
+++ b/lib/woocommerce_api/resource.rb
@@ -66,8 +66,11 @@ module WoocommerceAPI
       end
 
       if response.success?
+        # Restric format to be JSON
         begin
-          # Restric format to be JSON
+          # Some websites are including Byte Order Mark (BOM) on the response body
+          # which causes the response body to parsed correctly
+          response.body.sub!(/^\xEF\xBB\xBF/, '')
           JSON.parse(response.body)
         rescue JSON::ParserError => ex
           raise(ClientError.new('woocommerce_parse_json_error', response))

--- a/spec/woocommerce_api/resource_spec.rb
+++ b/spec/woocommerce_api/resource_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+shared_examples 'parsable response' do
+  let(:parsed_response) { WoocommerceAPI::Resource.parse_response(response) }
+  it 'parses response body to json' do
+    expect(parsed_response).to be_kind_of(Hash)
+    expect(parsed_response).to eq({"count" => 123})
+  end
+end
+describe WoocommerceAPI::Resource do
+  describe '.parse_response' do
+    context 'Parsing json body' do
+      it_should_behave_like 'parsable response' do
+        let(:response) { double(body: "{\"count\": 123}") }
+      end
+      it_should_behave_like 'parsable response' do
+        let(:response) { double(body: "unrelated text {\"count\": 123} blah") }
+      end
+      it_should_behave_like 'parsable response' do
+        let(:response) { double(body: "\uFEFF\uFEFF{\"count\": 123}") }
+      end
+
+      it 'raises error' do
+        response = double(body: "something nonesense")
+        expect{
+          WoocommerceAPI::Resource.parse_response(response)
+        }.to raise_error(JSON::ParserError)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
![screenshot 2016-09-21 17 59 41](https://cloud.githubusercontent.com/assets/768122/18707009/ca3740c0-8026-11e6-8a53-017f9e6ab931.png)
