### PR TITLE
[ENHANCEMENT] Provide a shorter error message when Woocomerce returns an HTML

### DIFF
--- a/lib/woocommerce_api/client_error.rb
+++ b/lib/woocommerce_api/client_error.rb
@@ -11,14 +11,22 @@ module WoocommerceAPI
                 else
                   extract_response(response.parsed_response)
                 end
-      super(message)
+      super(clean_html_response(message))
     rescue
       # There are cases where calling just response would raise a JSON::ParserError
       # but response.body and response.code would be returned normally.
-      super(response.body)
+      super(clean_html_response(response.body))
     end
 
   private
+
+    def clean_html_response(message)
+      if message.to_s.include?("DOCTYPE html")
+        "Woocommerce API returned an unexpected HTML response instead of JSON"
+      else
+        message
+      end
+    end
 
     def extract_response(response)
       case response
@@ -31,6 +39,5 @@ module WoocommerceAPI
         response.to_s.gsub(/[,.]$/, '')
       end
     end
-
   end
 end


### PR DESCRIPTION
The TG main app cannot do anything if Woocommerce keeps on returning an HTML response.
Sometimes the HTML response can tell which plugin is breaking the API but most of the time, it does not so i don't think the html response should still bubble up to TG main app. The gem should just give us a generic error.

<img width="1414" alt="screenshot 2017-12-20 14 57 57" src="https://user-images.githubusercontent.com/768122/34196686-293d9a32-e59e-11e7-926c-1925b7a543ff.png">
