### PR TITLE
[BUGFIX] Accept sync_type as additional parameters when saving products

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -7,6 +7,7 @@ require "virtus"
 
 require "woocommerce_api/concerns/associations"
 require "woocommerce_api/concerns/attribute_assignment"
+require "woocommerce_api/concerns/attribute_slicer"
 require "woocommerce_api/concerns/singleton"
 require "woocommerce_api/concerns/params_converter"
 require "woocommerce_api/client"

--- a/lib/woocommerce_api/concerns/attribute_slicer.rb
+++ b/lib/woocommerce_api/concerns/attribute_slicer.rb
@@ -1,0 +1,16 @@
+module WoocommerceAPI
+  module AttributeSlicer
+    def slice_by_sync_type(sync_type, attr_hash)
+      case sync_type&.to_sym
+      when :price
+        attr_hash.slice(:id, :regular_price, :sale_price)
+      when :stock_level
+        attr_hash.slice(:id, :stock_quantity, :in_stock)
+      when :price_and_stock_level
+        attr_hash.slice(:id, :regular_price, :sale_price, :stock_quantity, :in_stock)
+      else
+        attr_hash
+      end
+    end
+  end
+end

--- a/lib/woocommerce_api/resources/v1/product.rb
+++ b/lib/woocommerce_api/resources/v1/product.rb
@@ -15,7 +15,33 @@ module WoocommerceAPI
           product_attributes.delete('short_description')
         end
         product_attributes['backorders'] = nil if product_attributes['backorders'].blank?
+
+        if sync_type = options[:sync_type]
+          if product_attributes['variations'].present?
+            product_attributes = product_attributes.slice(:id, :variations)
+            variations = product_attributes['variations'].map do |attr_hash|
+              slice_by_sync_type(sync_type, attr_hash)
+            end
+            product_attributes['variations'] = variations
+          else
+            product_attributes = slice_by_sync_type(sync_type, product_attributes)
+          end
+        end
+
         product_attributes
+      end
+
+      def slice_by_sync_type(sync_type, attr_hash)
+        case sync_type.to_sym
+        when :price
+          attr_hash.slice(:id, :regular_price, :sale_price)
+        when :stock_level
+          attr_hash.slice(:id, :stock_quantity, :in_stock)
+        when :price_and_stock_level
+          attr_hash.slice(:id, :regular_price, :sale_price, :stock_quantity, :in_stock)
+        else
+          attr_hash
+        end
       end
 
       # Managed Attributes

--- a/lib/woocommerce_api/resources/v1/product.rb
+++ b/lib/woocommerce_api/resources/v1/product.rb
@@ -1,8 +1,12 @@
 require "woocommerce_api/resources/v1/variation"
+require "woocommerce_api/resources/v1/variation"
+
 
 module WoocommerceAPI
   module V1
     class Product < Resource
+      include WoocommerceAPI::AttributeSlicer
+
       def as_json(options={})
         product_attributes = super(options)
         if attributes[:wc_attributes] && !attributes[:wc_attributes].empty?
@@ -29,19 +33,6 @@ module WoocommerceAPI
         end
 
         product_attributes
-      end
-
-      def slice_by_sync_type(sync_type, attr_hash)
-        case sync_type.to_sym
-        when :price
-          attr_hash.slice(:id, :regular_price, :sale_price)
-        when :stock_level
-          attr_hash.slice(:id, :stock_quantity, :in_stock)
-        when :price_and_stock_level
-          attr_hash.slice(:id, :regular_price, :sale_price, :stock_quantity, :in_stock)
-        else
-          attr_hash
-        end
       end
 
       # Managed Attributes

--- a/lib/woocommerce_api/resources/v2/product.rb
+++ b/lib/woocommerce_api/resources/v2/product.rb
@@ -13,7 +13,17 @@ module WoocommerceAPI
 
         product_attributes.delete('images') unless options[:images]
         product_attributes['backorders'] = nil if product_attributes['backorders'].blank?
-        product_attributes
+
+        case options[:sync_type]&.to_sym
+        when :price
+          product_attributes.slice(:id, :regular_price, :sale_price)
+        when :stock_level
+          product_attributes.slice(:id, :stock_quantity, :in_stock)
+        when :price_and_stock_level
+          product_attributes.slice(:id, :regular_price, :sale_price, :stock_quantity, :in_stock)
+        else
+          product_attributes
+        end
       end
 
       # Managed Attributes

--- a/lib/woocommerce_api/resources/v2/product.rb
+++ b/lib/woocommerce_api/resources/v2/product.rb
@@ -3,6 +3,8 @@ require "woocommerce_api/resources/v2/variation"
 module WoocommerceAPI
   module V2
     class Product < Resource
+      include WoocommerceAPI::AttributeSlicer
+
       def as_json(options={})
         product_attributes = super(options)
 
@@ -14,16 +16,7 @@ module WoocommerceAPI
         product_attributes.delete('images') unless options[:images]
         product_attributes['backorders'] = nil if product_attributes['backorders'].blank?
 
-        case options[:sync_type]&.to_sym
-        when :price
-          product_attributes.slice(:id, :regular_price, :sale_price)
-        when :stock_level
-          product_attributes.slice(:id, :stock_quantity, :in_stock)
-        when :price_and_stock_level
-          product_attributes.slice(:id, :regular_price, :sale_price, :stock_quantity, :in_stock)
-        else
-          product_attributes
-        end
+        slice_by_sync_type(options[:sync_type], product_attributes)
       end
 
       # Managed Attributes

--- a/lib/woocommerce_api/resources/v2/variation.rb
+++ b/lib/woocommerce_api/resources/v2/variation.rb
@@ -20,7 +20,17 @@ module WoocommerceAPI
 
         variant_attributes.delete('image') unless options[:images]
         variant_attributes['backorders'] = nil if variant_attributes['backorders'].blank?
-        variant_attributes
+        
+        case options[:sync_type]&.to_sym
+        when :price
+          variant_attributes.slice(:id, :regular_price, :sale_price)
+        when :stock_level
+          variant_attributes.slice(:id, :stock_quantity, :in_stock)
+        when :price_and_stock_level
+          variant_attributes.slice(:id, :regular_price, :sale_price, :stock_quantity, :in_stock)
+        else
+          variant_attributes
+        end
       end
 
       attribute :id, Integer

--- a/lib/woocommerce_api/resources/v2/variation.rb
+++ b/lib/woocommerce_api/resources/v2/variation.rb
@@ -4,6 +4,8 @@ require "woocommerce_api/resources/legacy/dimensions"
 module WoocommerceAPI
   module V2
     class Variation < Resource
+      include WoocommerceAPI::AttributeSlicer
+
       def load(attributes)
         # Rename restricted attributes
         if attributes['attributes']
@@ -20,17 +22,8 @@ module WoocommerceAPI
 
         variant_attributes.delete('image') unless options[:images]
         variant_attributes['backorders'] = nil if variant_attributes['backorders'].blank?
-        
-        case options[:sync_type]&.to_sym
-        when :price
-          variant_attributes.slice(:id, :regular_price, :sale_price)
-        when :stock_level
-          variant_attributes.slice(:id, :stock_quantity, :in_stock)
-        when :price_and_stock_level
-          variant_attributes.slice(:id, :regular_price, :sale_price, :stock_quantity, :in_stock)
-        else
-          variant_attributes
-        end
+
+        slice_by_sync_type(options[:sync_type], variant_attributes)
       end
 
       attribute :id, Integer

--- a/woocommerce_api.gemspec
+++ b/woocommerce_api.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
     "lib/woocommerce_api/client_error.rb",
     "lib/woocommerce_api/concerns/associations.rb",
     "lib/woocommerce_api/concerns/attribute_assignment.rb",
+    "lib/woocommerce_api/concerns/attribute_slicer.rb",
     "lib/woocommerce_api/concerns/params_converter.rb",
     "lib/woocommerce_api/concerns/singleton.rb",
     "lib/woocommerce_api/oauth_client.rb",


### PR DESCRIPTION
Strip out unnecessary attributes when sync_type option is present when `.save` is called
 
![image](https://user-images.githubusercontent.com/768122/34764515-be940102-f629-11e7-978a-c16dba794c84.png)

This is solve an issue where we only want update certain attributes but we ended up passing the entire product payload back to woocommerce