### PR TITLE
[BUGFIX] Specify content-type if sending JSON payload

### DIFF
--- a/lib/woocommerce_api/oauth_client.rb
+++ b/lib/woocommerce_api/oauth_client.rb
@@ -8,11 +8,21 @@ module WoocommerceAPI
         payload[:method]        = http_method::METHOD.downcase
         payload[:request_uri]   = request_uri
         payload[:request_body]  = options[:body]
+        options[:headers] = { 'Content-Type' => 'application/json' } if valid_json?(options[:body])
         payload[:response_body] = super(http_method, request_uri, options, &block)
       end
     end
 
   private
+
+    def self.valid_json?(json)
+      return false if json.nil?
+
+      JSON.parse(json)
+      return true
+    rescue JSON::ParserError => e
+      return false
+    end
 
     def self.oauth_url(http_method, path, params={})
       oauth_options = Thread.current["WoocommerceAPI"]


### PR DESCRIPTION
## Summary
The `backorders` status will not get updated for some versions of Wordpress as the params are sent as an array instead of JSON.
Refer to https://github.com/woocommerce/woocommerce/blob/master/includes/legacy/api/v2/class-wc-api-products.php#L1124-L1134

## Before
![image](https://user-images.githubusercontent.com/9844923/67280494-e35ef600-f4ff-11e9-8b15-758dc87648b3.png)


## After
![image](https://user-images.githubusercontent.com/9844923/67279900-8d3d8300-f4fe-11e9-930b-46cdb5617239.png)
