### PR TITLE
[FEATURE] Add option for X-HTTP-Method-Override header

### DIFF
--- a/lib/woocommerce_api/client.rb
+++ b/lib/woocommerce_api/client.rb
@@ -1,6 +1,9 @@
+require 'woocommerce_api/concerns/request_headers'
+
 module WoocommerceAPI
   class Client
     include HTTParty
+    include WoocommerceAPI::RequestHeaders
 
     def self.default_options
       Thread.current["WoocommerceAPI"] || raise("Session has not been activated yet")
@@ -37,6 +40,7 @@ module WoocommerceAPI
         payload[:method]        = http_method::METHOD.downcase
         payload[:request_uri]   = path
         payload[:request_body]  = options[:body]
+        options[:headers]       = set_request_headers(options, http_method::METHOD)
         payload[:response_body] = super
       end
     end

--- a/lib/woocommerce_api/concerns/request_headers.rb
+++ b/lib/woocommerce_api/concerns/request_headers.rb
@@ -1,0 +1,32 @@
+module WoocommerceAPI
+  # Sets the HTTP request headers when making an API call to Woocommerce
+  module RequestHeaders
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def set_request_headers(options, http_method)
+        headers = options[:headers] || {}
+        headers['Content-Type'] = 'application/json' if valid_json?(options[:body])
+        headers['X-HTTP-Method-Override'] = http_method if http_method_override_header?(options, http_method)
+
+        headers
+      end
+
+      # https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_method-or-x-http-method-override-header
+      def http_method_override_header?(options, http_method)
+        http_method != 'GET' && http_method != 'POST' && options.key?(:http_method_override)
+      end
+
+      def valid_json?(json)
+        return false if json.nil?
+
+        JSON.parse(json)
+        return true
+      rescue JSON::ParserError => e
+        return false
+      end
+    end
+  end
+end

--- a/lib/woocommerce_api/oauth_client.rb
+++ b/lib/woocommerce_api/oauth_client.rb
@@ -1,6 +1,9 @@
+require 'woocommerce_api/concerns/request_headers'
+
 module WoocommerceAPI
   class OauthClient
     include HTTParty
+    include WoocommerceAPI::RequestHeaders
 
     def self.perform_request(http_method, path, options = {}, &block)
       ActiveSupport::Notifications.instrument("request.woocommerce_api") do |payload|
@@ -8,21 +11,12 @@ module WoocommerceAPI
         payload[:method]        = http_method::METHOD.downcase
         payload[:request_uri]   = request_uri
         payload[:request_body]  = options[:body]
-        options[:headers] = { 'Content-Type' => 'application/json' } if valid_json?(options[:body])
+        options[:headers]       = set_request_headers(options, http_method::METHOD)
         payload[:response_body] = super(http_method, request_uri, options, &block)
       end
     end
 
   private
-
-    def self.valid_json?(json)
-      return false if json.nil?
-
-      JSON.parse(json)
-      return true
-    rescue JSON::ParserError => e
-      return false
-    end
 
     def self.oauth_url(http_method, path, params={})
       oauth_options = Thread.current["WoocommerceAPI"]


### PR DESCRIPTION
Adds the option for one to use the `X-HTTP-Method-Override header` request header for the woocommerce API.

https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_method-or-x-http-method-override-header

One can specify to use this option by passing in `http_method_override` as a key in `options` when making the API request:

```
WoocommerceAPI::Product.http_request(:put, "/products/1", body: { sku: "123"}.to_json, http_method_override: true)
```