### PR TITLE
[BUGFIX] Fix signature generation when given array parameters

### DIFF
--- a/lib/woocommerce_api/oauth_client.rb
+++ b/lib/woocommerce_api/oauth_client.rb
@@ -24,12 +24,20 @@ module WoocommerceAPI
     def self.oauth_url(http_method, path, params={})
       oauth_options = Thread.current["WoocommerceAPI"]
       parsed_url = URI::parse("#{oauth_options[:base_uri]}#{path}")
+
       if parsed_url.query
         CGI::parse(parsed_url.query).each do |key, value|
-          params[key] = value[0]
+          if key.include?('[]')
+            value.each_with_index do |v, i|
+              params[key.gsub("[]", "[#{i}]")] = v
+            end
+          else
+            params[key] = value[0]
+          end
         end
         params = Hash[params.sort]
       end
+
       url = "http://#{parsed_url.host}#{parsed_url.path}"
 
       consumer_secret = if oauth_options[:version] == "v3" || oauth_options[:wordpress_api]


### PR DESCRIPTION
If the site is non-ssl and we make a call with an array value as parameter, signature generation is failing.

`WoocommerceAPI::Order.all(include: ["99201","12345"]` need to be converted to 

```
include[0] = 99201,
include[1] = 12345
```

in order to generate a proper signature. Logic in based on this line https://github.com/woocommerce/wc-api-php/blob/master/src/WooCommerce/HttpClient/OAuth.php#L112

### BEFORE
We are actually getting only the first item in the array because of the `value[0]`
```
 Sending: GET http://wpcommercetest.wpengine.com:80/wp-json/wc/v2/orders?include[]=98408
```

### AFTER
```
Sending: GET http://wpcommercetest.wpengine.com:80/wp-json/wc/v2/orders?include[0]=98408&include[1]=98395&include[2]=98109&include[3]=98054&include[4]=97796
```