### PR TITLE
[BUGFIX] Order line items can have a property 'attributes' with nil value

### DIFF
--- a/lib/woocommerce_api/resource.rb
+++ b/lib/woocommerce_api/resource.rb
@@ -12,7 +12,7 @@ module WoocommerceAPI
     def initialize(params={})
       self.class.include_root_in_json = !!legacy_api?
       @raw_params = params.dup
-      if params.is_a?(Hash) && params['attributes']
+      if params.is_a?(Hash) && params.has_key?('attributes')
         params['wc_attributes'] = params.delete('attributes')
       end
       load(params)


### PR DESCRIPTION
First time I get to see this error. It seems that line items can now have a property called "attributes"
and this will mess up our serializer 

https://tradegecko.atlassian.net/browse/TG-17873

<img width="890" alt="Screenshot 2020-01-14 15 33 51" src="https://user-images.githubusercontent.com/768122/72323511-e4a95480-36e3-11ea-8b83-993491de983c.png">
<img width="594" alt="Screenshot 2020-01-14 15 34 03" src="https://user-images.githubusercontent.com/768122/72323512-e541eb00-36e3-11ea-8ae4-83a246c4d98e.png">
