### PR TITLE
[BUGFIX] Set maintain_method_across_redirects option to true

### DIFF
--- a/lib/woocommerce_api/client.rb
+++ b/lib/woocommerce_api/client.rb
@@ -4,6 +4,7 @@ module WoocommerceAPI
   class Client
     include HTTParty
     include WoocommerceAPI::RequestHeaders
+    maintain_method_across_redirects true
 
     def self.default_options
       Thread.current["WoocommerceAPI"] || raise("Session has not been activated yet")


### PR DESCRIPTION
This solves this issue https://tradegecko.atlassian.net/browse/TG-21461

Currently if QuickBooks Commerce is making a `POST` request to Woocommerce and a 301 Moved Permanently was returned, HTTParty by default would follow the location but if `maintain_method_across_redirects` is not set to true then the request will be converted into a `GET` request.

See this line in HTTParty gem:
https://github.com/jnunemaker/httparty/blob/8ceb806b09d0e14ee5be00804a4fc2ce69eae079/lib/httparty/request.rb#L288

This PR will ensure that any POST requests that received a 301 response would retry with the same HTTP method