### PR TITLE
Ruby 3 removed `URI::encode`.

### DIFF
--- a/lib/woocommerce_api/oauth_client.rb
+++ b/lib/woocommerce_api/oauth_client.rb
@@ -52,7 +52,7 @@ module WoocommerceAPI
       params["oauth_timestamp"] = Time.new.to_i
       params["oauth_signature"] = CGI::escape(generate_oauth_signature(http_method, url, params, consumer_secret))
 
-      query_string = URI::encode(params.map{ |key, value| "#{key}=#{value}"}.join("&"))
+      query_string = URI.encode_www_form(params)
 
       "#{url}?#{query_string}"
     end


### PR DESCRIPTION
N.B. The output is different.

`URI.encode` converted spaces to `%20`, whilst `URI.encode_www_form` uses `+`. 
`URI.encode_www_form` does seem to be designed for exactly this usage though.